### PR TITLE
added proper comment support with '#'

### DIFF
--- a/java-properties.configuration.json
+++ b/java-properties.configuration.json
@@ -13,7 +13,7 @@
 	],
 	"comments": {
 		"blockComment": ["/*", "*/"],
-		"lineComment": "//"
+		"lineComment": "#"
 	},
 	"surroundingPairs": [
 		["{", "}"],


### PR DESCRIPTION
The commenting does not work in the current version which is referecned in #1. This PR adds support for that feature.